### PR TITLE
Bypassing mmap restrictions for enclave creation at address 0

### DIFF
--- a/sgx_encl.c
+++ b/sgx_encl.c
@@ -635,7 +635,7 @@ int sgx_encl_create(struct sgx_secs *secs)
 	}
 
 	down_read(&current->mm->mmap_sem);
-	ret = sgx_encl_find(current->mm, secs->base, &vma);
+	ret = sgx_encl_find(current->mm, secs->base + secs->size - PAGE_SIZE, &vma);
 	if (ret != -ENOENT) {
 		if (!ret)
 			ret = -EINVAL;
@@ -643,8 +643,9 @@ int sgx_encl_create(struct sgx_secs *secs)
 		goto out;
 	}
 
-	if (vma->vm_start != secs->base ||
-	    vma->vm_end != (secs->base + secs->size)
+	if (vma->vm_start < secs->base ||
+	    vma->vm_start > (secs->base + secs->size) ||
+	    vma->vm_end < (secs->base + secs->size)
 	    /* vma->vm_pgoff != 0 */) {
 		ret = -EINVAL;
 		up_read(&current->mm->mmap_sem);

--- a/sgx_main.c
+++ b/sgx_main.c
@@ -119,7 +119,7 @@ static unsigned long sgx_get_unmapped_area(struct file *file,
 					   unsigned long pgoff,
 					   unsigned long flags)
 {
-	if (len < 2 * PAGE_SIZE || (len & (len - 1)) || flags & MAP_PRIVATE)
+	if (flags & MAP_PRIVATE)
 		return -EINVAL;
 
 	/* On 64-bit architecture, allow mmap() to exceed 32-bit encl
@@ -144,7 +144,8 @@ static unsigned long sgx_get_unmapped_area(struct file *file,
 	if (IS_ERR_VALUE(addr))
 		return addr;
 
-	addr = (addr + (len - 1)) & ~(len - 1);
+	if (!(flags & MAP_FIXED))
+		addr = (addr + (len - 1)) & ~(len - 1);
 
 	return addr;
 }


### PR DESCRIPTION
The purpose of this PR is to gather feedback on a potential patch to [intel/linux-sgx-driver](https://github.com/intel/linux-sgx-driver).

Below is a draft for the PR to the linux-sgx-driver repository:

--------
Dear SGX driver team,

We are the maintainers of Graphene-SGX (https://github.com/oscarlab/graphene). We hope to relax a restriction in the Intel SGX driver, to allow loading unmodified executables on more platforms. 

To support loading an executable at a low address (e.g., 0x400000) in an enclave, we require creating enclave at address 0 (in order to satisfy the alignment requirements of enclaves). However, the current SGX driver for Linux disallows this scenario, for primarily two reasons:

1. The driver uses a VMA backed by `/dev/isgx` with the same beginning and ending addresses as the enclave.
2. Most Linux distributions restrict the lowest address that the users can create a VMA. The restriction can be relaxed with `sysctl vm.mmap_min_addr`, but the setting is global and allowing memory mapping at address 0 is generally considered dangerous (https://access.redhat.com/articles/20484). 

Currently, Graphene-SGX requires relaxing `sysctl vm.mmap_min_addr` but is not ideal for the security reason described above. To fix this problem, we need the SGX driver to support enclave creation at 0 even when `vm.mmap_min_addr` is not 0.

The following changes are made in this PR:

1. In `sgx_get_unmapped_area`, if `MAP_FIXED` is given in the flags, an VMA can be created at the exact address requested by the user. The VMA does not have to be an exact match to the enclave range.

2. In `sgx_encl_create`, we relaxed the check for the VMA address. The original check is as follows:
```
	if (vma->vm_start != secs->base ||
	    vma->vm_end != (secs->base + secs->size)
	    /* vma->vm_pgoff != 0 */) {
		ret = -EINVAL;
```
We propose relaxing this check to only testing the overlapping of the VMA and the enclave range at the last page of the enclave.

3. In `sgx_encl_create`,  we propose using the last page address (i.e., ending address - `PAGE_SIZE` ) to locate the VMA for the enclave instead of using the beginning address.

With this change, we hope to support unmodified Linux executables in SGX, without introducing security vulnerabilities to the rest of the platform. 